### PR TITLE
Change to only consider subtest status

### DIFF
--- a/tools/wave/src/testing/test-loader.js
+++ b/tools/wave/src/testing/test-loader.js
@@ -535,8 +535,10 @@ class TestLoader {
                 let hasSubFailed = false
                 if (refTest.subtests.length) {
                   hasSubFailed = refTest.subtests.some(sub => !(sub.status === 'PASS'))
+                } else {
+                  hasSubFailed = true // no subtests found, so none passed
                 }
-                return hasSubFailed ? hasSubFailed : !(refTest.status === 'OK')
+                return hasSubFailed
               })) continue
 
               tests[api].push(testPath)


### PR DESCRIPTION
Overall test files status is no longer used when building the list of to
tested files for a test session with references.