### PR TITLE
BUG: results page is empty unless refreshed many times

### DIFF
--- a/tools/wave/html/results.html
+++ b/tools/wave/html/results.html
@@ -508,12 +508,13 @@
       let collected = recentSessions.length
       const collectSessionDetails = (token, details, pinned) => {
         collected --
-        if (!details) return
-        sessionDetails.push({
-          token,
-          details,
-          pinned
-        })
+        if (details) {
+          sessionDetails.push({
+            token,
+            details,
+            pinned
+          })
+        }
         if (collected === 0) {
           sessionDetails.sort((sessionA, sessionB) => sessionA.token > sessionB.token ? 1 : -1)
             .forEach(session => {


### PR DESCRIPTION
Results were not shown if the last token was "invalid", no details were
being returned for the last token (when the last token was absent in a
database, 404 was returned instead, no "details").

issue #32 